### PR TITLE
Use clang++ by default, if you want to use GNU Compiler make CC=g++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+CC = clang++
 COM_OBJS +=\
 com/ltype.o \
 com/comf.o \
@@ -70,7 +71,7 @@ all: com_objs opt_objs
 INC=-I .
 %.o:%.cpp
 	@echo "build $<"
-	gcc $(CFLAGS) $(INC) -c $< -o $@
+	$(CC) $(CFLAGS) $(INC) -c $< -o $@
 
 com_objs: $(COM_OBJS)
 opt_objs: $(OPT_OBJS)

--- a/com/testbs.cpp
+++ b/com/testbs.cpp
@@ -184,7 +184,7 @@ void dump_segmgr(SegMgr<BitsPerSeg> & m)
 
     BitSet x;
     SList<SEG<BitsPerSeg>*> const* flst = m.get_free_list();
-    for (flst->get_head(&st); st != flst.end(); st = flst->get_next(st)) {
+    for (flst->get_head(&st); st != flst->end(); st = flst->get_next(st)) {
         SEG<BitsPerSeg> const* s = st->val();
         fprintf(g_tfile, "%d,", s->id);
         x.bunion(s->id);


### PR DESCRIPTION
Hi @stevenknown 

User might want to use clang++ :)

```
com/testbs.cpp:187:41: error: member reference base type 'const SList<SEG<BitsPerSeg> *> *' is not a structure or union
    for (flst->get_head(&st); st != flst.end(); st = flst->get_next(st)) {
                                    ~~~~^~~~
1 warning and 1 error generated.
```

So I simply changed ```flst.end()``` to ```flst->end()```, please review it, thanks a lot!

Regards,
Leslie Zhai - a [LLVM developer](https://reviews.llvm.org/p/xiangzhai/)